### PR TITLE
Add detailed job listings to last run summaries

### DIFF
--- a/src/Admin/Pages/DebugPage.php
+++ b/src/Admin/Pages/DebugPage.php
@@ -59,6 +59,7 @@ final class DebugPage
         }
 
         $jobSum = $this->logs->lastRunJobSummary();
+        $jobRows = $this->logs->lastRunJobEntries();
 
         echo '<p><strong>Run-ID:</strong> ' . esc_html($runId) . ' &nbsp; ';
         echo '<strong>Start:</strong> ' . esc_html($localize($started, $displayFormat)) . ' &nbsp; ';
@@ -73,6 +74,43 @@ final class DebugPage
         echo '<tr><td>Wörter</td><td>' . intval($jobSum['words'] ?? 0) . '</td></tr>';
         echo '<tr><td>Zeichen</td><td>' . intval($jobSum['chars'] ?? 0) . '</td></tr>';
         echo '</tbody></table>';
+
+        echo '<h3>Stellenangebote – Details</h3>';
+        if (empty($jobRows)) {
+            echo '<p>Keine Stellenanzeigen in diesem Lauf.</p>';
+        } else {
+            echo '<table class="widefat striped"><thead><tr>';
+            echo '<th>Zeit</th>';
+            echo '<th>Job-ID</th>';
+            echo '<th>Quelle→Ziel</th>';
+            echo '<th>Aktion</th>';
+            echo '<th>Status</th>';
+            echo '<th>Provider</th>';
+            echo '<th>Wörter</th>';
+            echo '<th>Zeichen</th>';
+            echo '<th>Nachricht</th>';
+            echo '</tr></thead><tbody>';
+            foreach ($jobRows as $row) {
+                $tsLocal = $localize($row['created_at'], $displayFormat);
+                $words = (int)$row['words_total'];
+                $chars = (int)$row['chars_total'];
+                $source = (string)($row['source_lang'] ?? '');
+                $target = (string)($row['target_lang'] ?? '');
+                $jobId = $row['job_id'] !== '' ? $row['job_id'] : '–';
+                echo '<tr>';
+                echo '<td>' . esc_html($tsLocal) . '</td>';
+                echo '<td>' . esc_html($jobId) . '</td>';
+                echo '<td>' . esc_html($source . ' → ' . $target) . '</td>';
+                echo '<td>' . esc_html($row['action']) . '</td>';
+                echo '<td>' . esc_html($row['status']) . '</td>';
+                echo '<td>' . esc_html($row['provider']) . '</td>';
+                echo '<td>' . esc_html($words) . '</td>';
+                echo '<td>' . esc_html($chars) . '</td>';
+                echo '<td style="max-width:260px;overflow:hidden;text-overflow:ellipsis">' . esc_html($row['message']) . '</td>';
+                echo '</tr>';
+            }
+            echo '</tbody></table>';
+        }
 
         echo '<h2>Schritte</h2>';
         echo '<table class="widefat striped"><thead><tr>';

--- a/src/Admin/Pages/LogPage.php
+++ b/src/Admin/Pages/LogPage.php
@@ -41,7 +41,37 @@ final class LogPage {
         echo '<p><strong>Summen</strong>: Einträge '.(int)$sums['entries'].', Wörter '.(int)$sums['words'].', Zeichen '.(int)$sums['chars'].'</p>';
 
         $last = $this->repo->lastRunJobSummary();
-        echo '<p><strong>Letzter Lauf – Stellenanzeigen:</strong> Übersetzt ' . (int)$last['entries'] . ' Einträge, Wörter ' . (int)$last['words'] . ', Zeichen ' . (int)$last['chars'] . '.</p>';
+        $lastRows = $this->repo->lastRunJobEntries();
+        echo '<h2>Letzter Lauf – Stellenanzeigen</h2>';
+        echo '<p><strong>Summen:</strong> Übersetzt ' . (int)$last['entries'] . ' Einträge, Wörter ' . (int)$last['words'] . ', Zeichen ' . (int)$last['chars'] . '.</p>';
+
+        if (!empty($lastRows)) {
+            echo '<table class="widefat striped"><thead><tr>';
+            echo '<th>Zeit</th><th>Job-ID</th><th>Quelle→Ziel</th><th>Provider</th><th>Aktion</th><th>Status</th><th>Wörter</th><th>Zeichen</th><th>Message</th>';
+            echo '</tr></thead><tbody>';
+            foreach ($lastRows as $row) {
+                $words = (int)$row['words_total'];
+                $chars = (int)$row['chars_total'];
+                $jobId = $row['job_id'] !== '' ? $row['job_id'] : '–';
+                $source = (string)($row['source_lang'] ?? '');
+                $target = (string)($row['target_lang'] ?? '');
+                $ts = esc_html(get_date_from_gmt($row['created_at'], 'Y-m-d H:i:s'));
+                echo '<tr>';
+                echo '<td>' . $ts . '</td>';
+                echo '<td>' . esc_html($jobId) . '</td>';
+                echo '<td>' . esc_html($source . ' → ' . $target) . '</td>';
+                echo '<td>' . esc_html($row['provider']) . '</td>';
+                echo '<td>' . esc_html($row['action']) . '</td>';
+                echo '<td>' . esc_html($row['status']) . '</td>';
+                echo '<td>' . esc_html($words) . '</td>';
+                echo '<td>' . esc_html($chars) . '</td>';
+                echo '<td>' . esc_html($row['message']) . '</td>';
+                echo '</tr>';
+            }
+            echo '</tbody></table>';
+        } else {
+            echo '<p>Keine Stellenanzeigen im letzten Lauf.</p>';
+        }
 
         echo '<table class="widefat striped"><thead><tr>';
         echo '<th>ID</th><th>Zeit</th><th>Post</th><th>Typ</th><th>Sprache</th><th>Provider</th><th>Aktion</th><th>Status</th><th>Wörter</th><th>Zeichen</th><th>Message</th>';

--- a/src/Domain/Repos/LogRepo.php
+++ b/src/Domain/Repos/LogRepo.php
@@ -117,4 +117,41 @@ final class LogRepo {
             'chars'  => (int)($row['chars'] ?? 0),
         ];
     }
+
+    public function lastRunJobEntries(): array
+    {
+        global $wpdb;
+        $table = $this->table();
+        $runId = $this->lastRunId();
+        if (!$runId) {
+            return [];
+        }
+
+        $sql = "SELECT id, created_at, source_lang, target_lang, provider, action, status,
+            words_title, chars_title, words_content, chars_content, message
+            FROM $table
+            WHERE run_id = %s AND post_type = 'job' AND action IN ('create','update','skip','error')
+            ORDER BY id ASC";
+
+        $rows = $wpdb->get_results($wpdb->prepare($sql, $runId), ARRAY_A);
+        if (!$rows) {
+            return [];
+        }
+
+        return array_map(function (array $row): array {
+            $row['words_total'] = (int)$row['words_title'] + (int)$row['words_content'];
+            $row['chars_total'] = (int)$row['chars_title'] + (int)$row['chars_content'];
+            $row['job_id'] = $this->extractJobId((string)$row['message']);
+            return $row;
+        }, $rows);
+    }
+
+    private function extractJobId(string $message): string
+    {
+        if (preg_match('/job_id=([^;\s]+)/i', $message, $m)) {
+            return trim($m[1]);
+        }
+
+        return '';
+    }
 }


### PR DESCRIPTION
## Summary
- extend the log repository with accessors for the last run's individual job entries
- render detailed per-job tables for the debug and logs admin pages so all job information is visible

## Testing
- php -l src/Domain/Repos/LogRepo.php
- php -l src/Admin/Pages/DebugPage.php
- php -l src/Admin/Pages/LogPage.php

------
https://chatgpt.com/codex/tasks/task_e_68d11fb12520832ca0582309a746467d