### PR TITLE
Add job limit selection for translations

### DIFF
--- a/src/Admin/Pages/DashboardPage.php
+++ b/src/Admin/Pages/DashboardPage.php
@@ -107,6 +107,14 @@ final class DashboardPage
         echo '<input type="hidden" name="action" value="osct_do_translate">';
         wp_nonce_field('osct_do_translate');
         echo '<p style="margin-bottom:8px"><label><input type="checkbox" name="osct_test" value="1" checked> Testlauf</label></p>';
+        echo '<p style="margin-bottom:8px">Stellenanzeigen-Limit: <select name="osct_jobs_limit">'
+            . '<option value="0" selected>Alle offenen Stellen</option>'
+            . '<option value="10">Erste 10</option>'
+            . '<option value="50">Erste 50</option>'
+            . '<option value="100">Erste 100</option>'
+            . '<option value="250">Erste 250</option>'
+            . '<option value="500">Erste 500</option>'
+            . '</select></p>';
         echo '<p style="margin-bottom:8px"><label><input type="checkbox" name="osct_do_jobs" value="1"> Stellenanzeigen</label></p>';
         echo '<p style="margin-bottom:8px"><label><input type="checkbox" name="osct_do_menu_pages" value="1"> Seiten im gewählten Menü</label></p>';
         echo '<p style="margin-bottom:8px"><label><input type="checkbox" name="osct_do_extra_pages" value="1"> Standardseiten</label></p>';

--- a/src/Core/Hooks.php
+++ b/src/Core/Hooks.php
@@ -113,6 +113,10 @@ final class Hooks
         $force = !empty($_POST['osct_force']);
         $runId = wp_generate_uuid4();
 
+        $limitRaw = isset($_POST['osct_jobs_limit']) ? (int)$_POST['osct_jobs_limit'] : 0;
+        $validLimits = [0, 10, 50, 100, 250, 500];
+        $jobsLimit = in_array($limitRaw, $validLimits, true) ? $limitRaw : 0;
+
         $menuRes = (new MenuSyncService($this->options, $this->langs))->bootstrap();
         set_transient('osct_menu_sync', $menuRes, 300);
 
@@ -122,6 +126,7 @@ final class Hooks
             'blocks'      => !empty($_POST['osct_do_blocks']),
             'jobs'        => !empty($_POST['osct_do_jobs']),
             'test'        => !empty($_POST['osct_test']),
+            'jobs_limit'  => $jobsLimit > 0 ? $jobsLimit : null,
         ];
 
         if (!empty($what['test'])) {

--- a/src/Translation/TranslationService.php
+++ b/src/Translation/TranslationService.php
@@ -195,6 +195,8 @@ final class TranslationService
             // Testlauf → nur 2 Stellenanzeigen
             if (!empty($what['test'])) {
                 $jr->setLimit(2);
+            } elseif (!empty($what['jobs_limit'])) {
+                $jr->setLimit((int)$what['jobs_limit']);
             }
 
             if (defined('OSCT_TEST_JOB_ID') && OSCT_TEST_JOB_ID) {


### PR DESCRIPTION
## Summary
- add a dropdown on the dashboard to pick a job translation batch size
- carry the selected limit through the translate handler to the translation service
- apply the requested limit when running job translations unless test mode is active

## Testing
- php -l src/Admin/Pages/DashboardPage.php
- php -l src/Core/Hooks.php
- php -l src/Translation/TranslationService.php

------
https://chatgpt.com/codex/tasks/task_e_68d1252acdc8832c93a1d3436b4f6100