### PR TITLE
Add summary logging and show translation metrics

### DIFF
--- a/src/Admin/Pages/DashboardPage.php
+++ b/src/Admin/Pages/DashboardPage.php
@@ -41,7 +41,17 @@ final class DashboardPage
 
         echo '<div class="wrap"><h1>OS Content Translator – Dashboard</h1>';
         if ($tr && is_array($tr)) {
-            echo '<div class="notice notice-success is-dismissible"><p>Übersetzung abgeschlossen. Neu: ' . intval($tr['created']) . ', übersprungen: ' . intval($tr['skipped']) . '.</p></div>';
+            $words = isset($tr['words']) ? intval($tr['words']) : null;
+            $chars = isset($tr['chars']) ? intval($tr['chars']) : null;
+            $metrics = '';
+            if ($words !== null || $chars !== null) {
+                $parts = [];
+                if ($words !== null) $parts[] = 'Wörter: ' . $words;
+                if ($chars !== null) $parts[] = 'Zeichen: ' . $chars;
+                if ($parts) $metrics = ' ' . implode(', ', $parts) . '.';
+            }
+
+            echo '<div class="notice notice-success is-dismissible"><p>Übersetzung abgeschlossen. Neu: ' . intval($tr['created']) . ', übersprungen: ' . intval($tr['skipped']) . '.' . esc_html($metrics) . '</p></div>';
         }
 
         $menuDbg = get_transient('osct_menu_debug');

--- a/src/Domain/Repos/LogRepo.php
+++ b/src/Domain/Repos/LogRepo.php
@@ -78,6 +78,7 @@ final class LogRepo {
         if (!empty($args['from'])) { $where.=' AND created_at >= %s'; $params[]=$args['from']; }
         if (!empty($args['to']))   { $where.=' AND created_at <= %s'; $params[]=$args['to']; }
         if (!empty($args['post_type'])) { $where.=' AND post_type = %s'; $params[]=$args['post_type']; }
+        $whereSummary = $where . " AND action <> 'summary'";
         $sql = "SELECT
             COUNT(*) as entries,
             SUM(words_title+words_content) as words,
@@ -87,7 +88,7 @@ final class LogRepo {
             SUM(CASE WHEN post_type = 'job' THEN chars_title+chars_content ELSE 0 END) as chars_job,
             SUM(CASE WHEN provider = 'google' THEN chars_title+chars_content ELSE 0 END) as chars_google,
             SUM(CASE WHEN provider = 'google' AND post_type = 'job' THEN chars_title+chars_content ELSE 0 END) as chars_google_job
-            FROM $table WHERE $where";
+            FROM $table WHERE $whereSummary";
         $row = $wpdb->get_row($wpdb->prepare($sql,$params), ARRAY_A);
         return [
             'entries'=>(int)($row['entries'] ?? 0),
@@ -125,12 +126,30 @@ final class LogRepo {
         $table = $this->table();
         $runId = $this->lastRunId();
         if (!$runId) return ['entries' => 0, 'words' => 0, 'chars' => 0];
+        $summarySql = "SELECT words_title, chars_title, message FROM $table
+            WHERE run_id = %s AND post_type = 'job' AND action = 'summary'
+            ORDER BY id DESC LIMIT 1";
+        $summary = $wpdb->get_row($wpdb->prepare($summarySql, $runId), ARRAY_A);
+        if ($summary) {
+            $counts = [
+                'entries' => 0,
+                'words'   => (int)($summary['words_title'] ?? 0),
+                'chars'   => (int)($summary['chars_title'] ?? 0),
+            ];
+
+            if (preg_match('/jobs=(\d+)/', (string)$summary['message'], $m)) {
+                $counts['entries'] = (int)$m[1];
+            }
+
+            return $counts;
+        }
+
         $sql = "SELECT
-        COUNT(*) as entries,
-        SUM(words_title+words_content) as words,
-        SUM(chars_title+chars_content) as chars
-        FROM $table
-        WHERE run_id = %s AND post_type = 'job' AND action IN ('create','update')";
+            COUNT(*) as entries,
+            SUM(words_title+words_content) as words,
+            SUM(chars_title+chars_content) as chars
+            FROM $table
+            WHERE run_id = %s AND post_type = 'job' AND action IN ('create','update')";
         $row = $wpdb->get_row($wpdb->prepare($sql, $runId), ARRAY_A);
         return [
             'entries' => (int)($row['entries'] ?? 0),

--- a/src/Translation/Jobs/JobsRunner.php
+++ b/src/Translation/Jobs/JobsRunner.php
@@ -281,6 +281,30 @@ final class JobsRunner
       }
     }
 
+    $this->logs->insert([
+      'run_id'         => $this->currentRunId(),
+      'post_id'        => 0,
+      'post_type'      => 'job',
+      'source_lang'    => $source,
+      'target_lang'    => '-',
+      'provider'       => 'mixed',
+      'action'         => 'summary',
+      'status'         => 'info',
+      'words_title'    => $words,
+      'chars_title'    => $chars,
+      'words_content'  => 0,
+      'chars_content'  => 0,
+      'src_hash'       => '',
+      'message'        => sprintf(
+        'Summary; jobs=%d; created=%d; skipped=%d; words=%d; chars=%d',
+        $created + $skipped,
+        $created,
+        $skipped,
+        $words,
+        $chars
+      ),
+    ]);
+
     return ['created' => $created, 'skipped' => $skipped, 'words' => $words, 'chars' => $chars];
   }
 


### PR DESCRIPTION
## Summary
- log a dedicated job summary entry at the end of each JobsRunner execution so the totals of words and characters are visible in the log list
- keep aggregate SQL in LogRepo from double-counting the new summary rows and let the last-run widget read the summary if available
- surface the word and character totals in the dashboard success notice after a translation run

## Testing
- php -l src/Translation/Jobs/JobsRunner.php
- php -l src/Domain/Repos/LogRepo.php
- php -l src/Admin/Pages/DashboardPage.php

------
https://chatgpt.com/codex/tasks/task_e_68d3d91e6f58832cb0a15e5f931ddc92