### PR TITLE
Add translation support for cloned menu titles

### DIFF
--- a/src/Core/Hooks.php
+++ b/src/Core/Hooks.php
@@ -117,7 +117,11 @@ final class Hooks
         $validLimits = [0, 3, 10, 50, 100, 250, 500];
         $jobsLimit = in_array($limitRaw, $validLimits, true) ? $limitRaw : 0;
 
-        $menuRes = (new MenuSyncService($this->options, $this->langs))->bootstrap();
+        $menuRes = (new MenuSyncService(
+            $this->options,
+            $this->langs,
+            fn(string $text, string $lang, string $source) => $this->translator->quickTranslate($text, $lang, $source)
+        ))->bootstrap();
         set_transient('osct_menu_sync', $menuRes, 300);
 
         $what = [

--- a/src/Translation/TranslationService.php
+++ b/src/Translation/TranslationService.php
@@ -127,6 +127,25 @@ final class TranslationService
         return '';
     }
 
+    public function quickTranslate(string $text, string $targetLang, ?string $sourceLang = null): string
+    {
+        if ($text === '') {
+            return '';
+        }
+
+        if (trim($text) === '') {
+            return $text;
+        }
+
+        $source = $sourceLang ?: $this->langs->default();
+        if ($targetLang === '' || $targetLang === $source) {
+            return $text;
+        }
+
+        $translated = $this->t($text, $targetLang, $source);
+        return $translated !== '' ? $translated : $text;
+    }
+
     public function state(int $srcId, string $lang): string
     {
         if (!function_exists('pll_get_post')) return 'missing';


### PR DESCRIPTION
## Summary
- inject an optional translator into the menu sync service so cloned menu item titles are translated per language and logged for debugging
- expose a reusable `quickTranslate` helper on the translation service and pass it to the menu sync bootstrapper

## Testing
- php -l src/Features/Menus/MenuSyncService.php
- php -l src/Translation/TranslationService.php
- php -l src/Core/Hooks.php

------
https://chatgpt.com/codex/tasks/task_e_68d69886271c832c93bf61ddf379eabc